### PR TITLE
Experimental fix for the schema version 500 error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ deploy_prod: ## Deploy to datasette.biglocalnews.org
 		-m prod.yml \
 		--create-volume 1 \
 		--create-db biglocalnews \
+		--branch 'schema-version-fix-0.64.x' \
 		--install https://github.com/simonw/datasette-big-local/archive/refs/heads/main.zip \
 		--install datasette-cluster-map \
 		--install datasette-vega \
@@ -83,6 +84,7 @@ deploy_dev: ## Deploy to dev-datasette.biglocalnews.org
 		-m dev.yml \
 		--create-volume 1 \
 		--create-db dev-biglocalnews \
+		--branch 'schema-version-fix-0.64.x' \
 		--install https://github.com/simonw/datasette-big-local/archive/refs/heads/main.zip \
 		--install datasette-cluster-map \
 		--install datasette-vega \


### PR DESCRIPTION
Refs:
- #1 
- https://github.com/simonw/datasette/issues/2058

I've been unable to replicate the 500 "attempt to write a readonly database" error myself, but from the stack trace I believe it's due to `PRAGMA schema_version` being unavailable for some reason.

I've pushed an experimental branch of Datasette that falls back on a different mechanism for when that query cannot be run.

This change updates the `Makefile` to deploy the Big Local Datasette instance using this new experimental branch. We should try this and see if it resolves the error.